### PR TITLE
Use SSL, remove puts and fixed param name

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -73,7 +73,6 @@ module Pipedrive
       #
       # @param [HTTParty::Response] response
       def bad_response(response, params={})
-        puts params.inspect
         if response.class == HTTParty::Response
           raise HTTParty::ResponseError, response
         end

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,7 +94,7 @@ module Pipedrive
           end
           data
         else
-          bad_response(res,attrs)
+          bad_response(res, options)
         end
       end
 


### PR DESCRIPTION
Pipedrive API has deprecated HTTP access.
